### PR TITLE
Implement async LRU cache for RPC response layer

### DIFF
--- a/src/rpc_cache_layer.rs
+++ b/src/rpc_cache_layer.rs
@@ -1,7 +1,73 @@
 use crate::config::AppConfig;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use tokio::time::{Duration, Instant};
 
-pub async fn start_rpc_cache(_config: &AppConfig) -> anyhow::Result<()> {
-    println!(" RPC cache layer running...");
+#[derive(Debug)]
+struct CachedResponse {
+    value: String,
+    expires_at: Instant,
+}
+
+type SharedCache = Arc<Mutex<LruCache<String, CachedResponse>>>;
+
+pub async fn start_rpc_cache(config: &AppConfig) -> anyhow::Result<()> {
+    println!(" Starting RPC LRU cache (size: {})", config.cache_size);
+
+    let cache: SharedCache = Arc::new(Mutex::new(LruCache::new(
+        NonZeroUsize::new(config.cache_size).unwrap(),
+    )));
+
+    // Spawn fake RPC requests to demonstrate caching
+    let cache_clone = cache.clone();
+    tokio::spawn(async move {
+        loop {
+            let keys = vec!["getBalance:Orly".to_string(), "getAccountInfo:Wallet123".to_string()];
+            for key in keys {
+                let result = handle_rpc_request(cache_clone.clone(), key.clone()).await;
+                println!("→ Response: {}", result);
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    });
+
     Ok(())
+}
+
+async fn handle_rpc_request(cache: SharedCache, key: String) -> String {
+    let mut cache_lock = cache.lock().await;
+
+    // Check cache
+    if let Some(entry) = cache_lock.get(&key) {
+        if Instant::now() < entry.expires_at {
+            println!(" Cache hit for {}", key);
+            return format!("(cached) {}", entry.value);
+        } else {
+            println!(" Cache expired for {}", key);
+        }
+    } else {
+        println!(" Cache miss for {}", key);
+    }
+
+    // Simulate fetching fresh data (e.g., via real RPC later)
+    let fresh_value = simulate_rpc_fetch(&key).await;
+
+    // Cache for 10 seconds
+    let new_entry = CachedResponse {
+        value: fresh_value.clone(),
+        expires_at: Instant::now() + Duration::from_secs(10),
+    };
+    cache_lock.put(key.clone(), new_entry);
+
+    fresh_value
+}
+
+async fn simulate_rpc_fetch(key: &str) -> String {
+    // Simulate network delay
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    format!("FreshData({})", key)
 }
 


### PR DESCRIPTION
This PR introduces an asynchronous in-memory LRU cache layer for Solana RPC responses.

Key Features:
Adds rpc_cache_layer.rs module with:
Async-safe LruCache using tokio::sync::Mutex
Cache entries with TTL (10s by default)
Support for common RPC-like keys: getBalance, getAccountInfo
Logs cache hits, misses, and expirations
Demonstrates simulated RPC fetches for now (placeholder for future integration with solana-client)
Pulls cache_size from Config.toml via AppConfig