### PR TITLE
feat: add Solana priority fee advisor

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,14 +2,15 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use solana_validator_optimizer::{
-    config::AppConfig, config_autotuner, metrics, rpc_cache_layer, rpc_health, snapshot_prefetcher,
+    config::AppConfig, config_autotuner, metrics, priority_fee, rpc_cache_layer, rpc_health,
+    snapshot_prefetcher,
 };
 
 #[derive(Parser, Debug)]
 #[command(
     name = "svo",
     version = env!("CARGO_PKG_VERSION"),
-    about = "Solana Validator Optimizer CLI (snapshot prefetch, RPC cache, metrics, RPC health diagnostics)."
+    about = "Solana Validator Optimizer CLI (snapshot prefetch, RPC cache, metrics, RPC health diagnostics, priority fee advice)."
 )]
 struct Cli {
     /// Path to config file (default: ./Config.toml)
@@ -45,6 +46,21 @@ enum Commands {
         endpoint: Option<String>,
 
         /// Output report as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Estimate Solana transaction priority fee and provide basic fee guidance
+    FeeAdvice {
+        /// Compute unit limit for the transaction
+        #[arg(long)]
+        compute_units: u64,
+
+        /// Compute unit price in micro-lamports
+        #[arg(long)]
+        micro_lamports: u64,
+
+        /// Output advice as JSON
         #[arg(long)]
         json: bool,
     },
@@ -153,6 +169,35 @@ async fn main() -> Result<()> {
                         println!("- {warning}");
                     }
                 }
+            }
+        }
+
+        Commands::FeeAdvice {
+            compute_units,
+            micro_lamports,
+            json,
+        } => {
+            let advice = priority_fee::advise_priority_fee(compute_units, micro_lamports);
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&advice)?);
+            } else {
+                println!("Solana Priority Fee Advice");
+                println!("Compute Units: {}", advice.compute_units);
+                println!(
+                    "Compute Unit Price: {} micro-lamports",
+                    advice.micro_lamports_per_compute_unit
+                );
+                println!(
+                    "Estimated Priority Fee: {} lamports",
+                    advice.estimated_priority_fee_lamports
+                );
+                println!(
+                    "Estimated Priority Fee: {:.9} SOL",
+                    advice.estimated_priority_fee_sol
+                );
+                println!("Risk Level: {}", advice.risk_level);
+                println!("Recommendation: {}", advice.recommendation);
             }
         }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod blockstream_optimizer;
 pub mod config;
 pub mod config_autotuner;
 pub mod metrics;
+pub mod priority_fee;
 pub mod rpc_cache_layer;
 pub mod rpc_health;
 pub mod snapshot_prefetcher;

--- a/crates/core/src/priority_fee.rs
+++ b/crates/core/src/priority_fee.rs
@@ -1,0 +1,107 @@
+use serde::Serialize;
+
+const MICRO_LAMPORTS_PER_LAMPORT: u64 = 1_000_000;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PriorityFeeAdvice {
+    pub compute_units: u64,
+    pub micro_lamports_per_compute_unit: u64,
+    pub estimated_priority_fee_lamports: u64,
+    pub estimated_priority_fee_sol: f64,
+    pub risk_level: String,
+    pub recommendation: String,
+}
+
+pub fn advise_priority_fee(
+    compute_units: u64,
+    micro_lamports_per_compute_unit: u64,
+) -> PriorityFeeAdvice {
+    let estimated_priority_fee_lamports =
+        compute_units.saturating_mul(micro_lamports_per_compute_unit) / MICRO_LAMPORTS_PER_LAMPORT;
+
+    let estimated_priority_fee_sol = estimated_priority_fee_lamports as f64 / 1_000_000_000_f64;
+
+    let (risk_level, recommendation) = classify_fee(
+        compute_units,
+        micro_lamports_per_compute_unit,
+        estimated_priority_fee_lamports,
+    );
+
+    PriorityFeeAdvice {
+        compute_units,
+        micro_lamports_per_compute_unit,
+        estimated_priority_fee_lamports,
+        estimated_priority_fee_sol,
+        risk_level,
+        recommendation,
+    }
+}
+
+fn classify_fee(
+    compute_units: u64,
+    micro_lamports_per_compute_unit: u64,
+    estimated_priority_fee_lamports: u64,
+) -> (String, String) {
+    if compute_units == 0 {
+        return (
+            "Invalid".to_string(),
+            "Compute units must be greater than zero.".to_string(),
+        );
+    }
+
+    if micro_lamports_per_compute_unit == 0 {
+        return (
+            "Low".to_string(),
+            "No priority fee is configured. This may be acceptable during low network activity but can reduce transaction landing reliability during congestion.".to_string(),
+        );
+    }
+
+    if estimated_priority_fee_lamports < 100 {
+        return (
+            "Low".to_string(),
+            "Priority fee is very low. Consider increasing compute unit price for production marketplace, reward, or high-frequency transaction flows.".to_string(),
+        );
+    }
+
+    if estimated_priority_fee_lamports <= 5_000 {
+        return (
+            "Normal".to_string(),
+            "Priority fee appears reasonable for moderate load. Monitor transaction landing rate and RPC latency in production.".to_string(),
+        );
+    }
+
+    if estimated_priority_fee_lamports <= 50_000 {
+        return (
+            "Elevated".to_string(),
+            "Priority fee is elevated. This may improve landing probability during congestion but should be monitored for cost impact.".to_string(),
+        );
+    }
+
+    (
+        "High".to_string(),
+        "Priority fee is high. Verify that this is intentional and justified by congestion, latency-sensitive flows, or high-value transactions.".to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculates_priority_fee_in_lamports() {
+        let advice = advise_priority_fee(250_000, 1_000);
+        assert_eq!(advice.estimated_priority_fee_lamports, 250);
+    }
+
+    #[test]
+    fn detects_zero_compute_units() {
+        let advice = advise_priority_fee(0, 1_000);
+        assert_eq!(advice.risk_level, "Invalid");
+    }
+
+    #[test]
+    fn detects_zero_priority_fee() {
+        let advice = advise_priority_fee(250_000, 0);
+        assert_eq!(advice.risk_level, "Low");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Solana Priority Fee Advisor to help estimate priority fees based on compute unit limit and compute unit price in micro-lamports.

This extends `solana-validator-optimizer` from validator/RPC tooling toward broader Solana infrastructure diagnostics and transaction reliability support.

## Added

- `priority_fee` core module
- `FeeAdvice` CLI command
- Priority fee calculation in lamports and SOL
- Basic risk classification
- Human-readable and JSON output support
- Unit tests for fee calculation and edge cases

## Example

```bash
cargo run -p solana-validator-optimizer-cli -- fee-advice \
  --compute-units 250000 \
  --micro-lamports 1000

## Validation

```bash
cargo fmt
cargo check
cargo test
cargo run -p solana-validator-optimizer-cli -- fee-advice \
  --compute-units 250000 \
  --micro-lamports 1000

All tests passed.